### PR TITLE
Introduced types to make event type independent from the shceduler pa…

### DIFF
--- a/events/datatypes.go
+++ b/events/datatypes.go
@@ -5,55 +5,10 @@ package events
 import (
 	"log"
 	"sync"
-	"time"
 
 	"github.com/caffix/queue"
 	"github.com/google/uuid"
-	"github.com/owasp-amass/engine/sessions"
-)
-
-// Event types (are used to query the Registry adn identify the action to be executed)
-type EventType int
-
-const (
-	// SystemType is used to identify system events
-	EventTypeSystem EventType = iota
-	// EventTypeLog is used to log a message to the log file
-	EventTypeLog
-	// EventTypeCustom is used to execute a custom function
-	EventTypeCustom
-	// AssetType is used to identify asset events
-	EventTypeAsset
-	// Add more event types here:
-	// ...
-)
-
-var (
-	// Event types names (used to query the Registry)
-	EventTypeNames = map[EventType]string{
-		EventTypeSystem: "System",
-		EventTypeLog:    "Log",
-		EventTypeCustom: "Custom",
-		EventTypeAsset:  "Asset",
-		// Add more event types here:
-		// ...
-	}
-
-	MaxEventTypes = len(EventTypeNames)
-)
-
-// Event states (are used to control the event flow)
-type EventState int
-
-const (
-	StateDefault EventState = iota // Event is in default state
-	// (normally used when the event is created)
-	StateProcessable // Event is processable (all dependencies are met)
-	StateWaiting     // Event is waiting (some dependencies are not met)
-	StateDone        // Event is done (already processed)
-	StateInProcess   // Event is in process (being processed)
-	StateCancelled   // Event is cancelled (not processed)
-	StateError       // Event is in error (not processed)
+	"github.com/owasp-amass/engine/types"
 )
 
 // Global variables
@@ -61,40 +16,6 @@ var (
 	// zeroUUID is used to indicate that an event has no dependencies
 	zeroUUID = uuid.UUID{}
 )
-
-// Event is the struct that represents an event
-// This struct it's kind of the "currency of exchange" between the scheduler
-// and the functions that create and process the events
-type Event struct {
-	UUID      uuid.UUID           /* Event UUID */
-	SessionID uuid.UUID           /* Session UUID */
-	Name      string              /* Event name */
-	Timestamp time.Time           /* Event timestamp */
-	Type      EventType           /* Event type */
-	State     EventState          /* Event state (processable, waiting, done, in process) */
-	DependOn  []uuid.UUID         /* Events this event "depends on" */
-	Action    func(e Event) error /* Event handler function (action) (normally populated by querying the
-	-                                Registry)
-	-                              */
-	Priority    int /* Event priority (normally populated by querying the Registry) */
-	RepeatEvery int /* Event repeat every X milliseconds
-	-                  0 means repeat immediately
-	-                  n means repeat after n milliseconds (n > 0)
-	-                  Event won't be repeated if RepeatTimes is 0
-	-                */
-	RepeatTimes int /* Event repeat times (normally populated by querying the Registry)
-	-                  -1 means repeat forever
-	-                   0 means don't repeat
-	-                   n means repeat n times
-	-                 */
-	Data interface{} /* This field can hold any data type (normally populated by the function
-	-                   that creates the event, and used by the function that processes the
-	-                   event)
-	-                 */
-	timeout time.Time  /* Timeout timer (used to cancel the event if it's not processed in time) */
-	Sched   *Scheduler /* Pointer to the scheduler that created the event */
-	Session *sessions.Session
-}
 
 type SchedulerState int
 
@@ -112,12 +33,12 @@ const (
 //   - Sub schedulers, used to schedule and process events, they are allocated on the stack and
 //     they are initialized by calling the NewScheduler() function.
 type Scheduler struct {
-	q                     queue.Queue          // Events Queue (Queue to store events)
-	mutex                 sync.Mutex           // Mutex to protect the queue when fetching the next event
-	events                map[uuid.UUID]*Event // Map to quickly look up events by UUID
-	CurrentRunningActions int                  // Number of actions currently running
-	state                 SchedulerState       // Scheduler state (running, stopped, paused)
-	logger                *log.Logger          // Logger
+	q                     queue.Queue                // Events Queue (Queue to store events)
+	mutex                 sync.Mutex                 // Mutex to protect the queue when fetching the next event
+	events                map[uuid.UUID]*types.Event // Map to quickly look up events by UUID
+	CurrentRunningActions int                        // Number of actions currently running
+	state                 SchedulerState             // Scheduler state (running, stopped, paused)
+	logger                *log.Logger                // Logger
 }
 
 // ProcessConfig is the struct that represents the configuration used to process the events

--- a/events/scheduler_test.go
+++ b/events/scheduler_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/owasp-amass/engine/types"
 )
 
 // Global constants
@@ -36,7 +37,7 @@ func setup() {
 
 	exitWhenEmpty := flag.Bool("exitWhenEmpty", true, "Exit when the queue is empty")
 	checkEvent := flag.Bool("checkEvent", true, "Print event details when processing")
-	executeAction := flag.Bool("executeAction", true, "Execute the event action when processing")
+	executeAction := flag.Bool("executeAction", true, "Execute the types.Event action when processing")
 	returnIfFound := flag.Bool("returnIfFound", false, "Return if an event is found")
 
 	flag.Parse()
@@ -75,7 +76,7 @@ func TestSchedule001(t *testing.T) {
 		t.Errorf(errMsgSchedulerFailedToInit)
 	}
 
-	e := Event{
+	e := types.Event{
 		Name: "Test event",
 		Data: TestEvent{
 			Message: testMsg,
@@ -105,7 +106,7 @@ func TestSchedule002(t *testing.T) {
 		t.Errorf(errMsgSchedulerFailedToInit)
 	}
 
-	e := Event{
+	e := types.Event{
 		UUID: uuid.New(),
 		Name: "Test event (TestSchedule002)",
 		Data: TestEvent{
@@ -137,10 +138,10 @@ func TestSchedule003(t *testing.T) {
 		t.Errorf(errMsgSchedulerFailedToInit)
 	}
 
-	e := Event{
+	e := types.Event{
 		UUID:  uuid.New(),
 		Name:  "Test event (TestSchedule003)",
-		State: StateDone,
+		State: types.StateDone,
 		Data: TestEvent{
 			Message: testMsg,
 		},
@@ -171,10 +172,10 @@ func TestSchedule004(t *testing.T) {
 		t.Errorf(errMsgSchedulerFailedToInit)
 	}
 
-	e := Event{
+	e := types.Event{
 		UUID:     uuid.New(),
 		Name:     "Test event (TestSchedule004)",
-		State:    StateDone,
+		State:    types.StateDone,
 		DependOn: []uuid.UUID{uuid.New()},
 		Data: TestEvent{
 			Message: testMsg,
@@ -207,10 +208,10 @@ func TestSchedule005(t *testing.T) {
 		t.Errorf(errMsgSchedulerFailedToInit)
 	}
 
-	e := Event{
+	e := types.Event{
 		UUID:      uuid.New(),
 		Name:      "Test event (TestSchedule005)",
-		State:     StateDone,
+		State:     types.StateDone,
 		DependOn:  []uuid.UUID{uuid.New()},
 		Timestamp: time.Now(),
 		Data: TestEvent{
@@ -245,19 +246,19 @@ func TestSchedule006(t *testing.T) {
 		t.Errorf(errMsgSchedulerFailedToInit)
 	}
 
-	e := Event{
+	e := types.Event{
 		UUID:      uuid.New(),
 		Name:      "Test event (TestSchedule006)",
-		State:     StateDone,
+		State:     types.StateDone,
 		DependOn:  []uuid.UUID{uuid.New()},
 		Timestamp: time.Now(),
-		Action: func(e Event) error {
+		Action: func(e types.Event) error {
 			data, ok := e.Data.(TestEvent) // Type assertion
 			if ok {
 				fmt.Println(data)
 				return nil
 			}
-			SetEventState(&e, StateError)
+			SetEventState(&e, types.StateError)
 			return fmt.Errorf("Error: Type assertion failed")
 		},
 		Data: TestEvent{
@@ -293,21 +294,21 @@ func TestSchedule007(t *testing.T) {
 		t.Errorf(errMsgSchedulerFailedToInit)
 	}
 
-	e := Event{
+	e := types.Event{
 		UUID:      uuid.New(),
 		Name:      "Test event (TestSchedule007)",
-		State:     StateDone,
+		State:     types.StateDone,
 		DependOn:  []uuid.UUID{uuid.New()},
 		Timestamp: time.Now(),
-		Action: func(e Event) error {
+		Action: func(e types.Event) error {
 			fmt.Println(e.Data.(TestEvent).Message)
-			SetEventState(&e, StateDone)
+			SetEventState(&e, types.StateDone)
 			return nil
 		},
 		Data: TestEvent{
 			Message: testMsg,
 		},
-		Type: EventTypeCustom,
+		Type: types.EventTypeCustom,
 	}
 	err = s.Schedule(&e)
 	if err != nil {
@@ -340,21 +341,21 @@ func TestSchedule008(t *testing.T) {
 		t.Errorf(errMsgSchedulerFailedToInit)
 	}
 
-	e := Event{
+	e := types.Event{
 		UUID:      uuid.New(),
 		Name:      "Test event (TestSchedule008)",
-		State:     StateDone,
+		State:     types.StateDone,
 		DependOn:  []uuid.UUID{uuid.New()},
 		Timestamp: time.Now(),
-		Action: func(e Event) error {
+		Action: func(e types.Event) error {
 			fmt.Println(e.Data.(TestEvent).Message)
-			SetEventState(&e, StateDone)
+			SetEventState(&e, types.StateDone)
 			return nil
 		},
 		Data: TestEvent{
 			Message: testMsg,
 		},
-		Type:     EventTypeCustom,
+		Type:     types.EventTypeCustom,
 		Priority: 1,
 	}
 	err = s.Schedule(&e)
@@ -389,21 +390,21 @@ func TestSchedule009(t *testing.T) {
 		t.Errorf(errMsgSchedulerFailedToInit)
 	}
 
-	e := Event{
+	e := types.Event{
 		UUID:      uuid.New(),
 		Name:      "Test event (TestSchedule009)",
-		State:     StateDone,
+		State:     types.StateDone,
 		DependOn:  []uuid.UUID{uuid.New()},
 		Timestamp: time.Now(),
-		Action: func(e Event) error {
+		Action: func(e types.Event) error {
 			fmt.Println(e.Data.(TestEvent).Message)
-			SetEventState(&e, StateDone)
+			SetEventState(&e, types.StateDone)
 			return nil
 		},
 		Data: TestEvent{
 			Message: testMsg,
 		},
-		Type:        EventTypeCustom,
+		Type:        types.EventTypeCustom,
 		Priority:    1,
 		RepeatEvery: 1,
 	}
@@ -440,21 +441,21 @@ func TestSchedule010(t *testing.T) {
 		t.Errorf(errMsgSchedulerFailedToInit)
 	}
 
-	e := Event{
+	e := types.Event{
 		UUID:      uuid.New(),
 		Name:      "Test event (TestSchedule010) Random UUID as dependency",
-		State:     StateDone,
+		State:     types.StateDone,
 		DependOn:  []uuid.UUID{uuid.New()},
 		Timestamp: time.Now(),
-		Action: func(e Event) error {
+		Action: func(e types.Event) error {
 			fmt.Println(e.Data.(TestEvent).Message)
-			SetEventState(&e, StateDone)
+			SetEventState(&e, types.StateDone)
 			return nil
 		},
 		Data: TestEvent{
 			Message: testMsg,
 		},
-		Type:        EventTypeCustom,
+		Type:        types.EventTypeCustom,
 		Priority:    1,
 		RepeatEvery: 1,
 		RepeatTimes: 1,
@@ -484,7 +485,7 @@ func TestSchedule011(t *testing.T) {
 		t.Errorf(errMsgSchedulerFailedToInit)
 	}
 
-	e0 := Event{
+	e0 := types.Event{
 		Name: "Test event 0 (TestSchedule011)",
 	}
 	err = s.Schedule(&e0)
@@ -492,7 +493,7 @@ func TestSchedule011(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
-	e1 := Event{
+	e1 := types.Event{
 		Name:     "Test event 1 (TestSchedule011)",
 		DependOn: []uuid.UUID{e0.UUID},
 	}
@@ -501,7 +502,7 @@ func TestSchedule011(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
-	e2 := Event{
+	e2 := types.Event{
 		Name:     "Test event 2 (TestSchedule011)",
 		DependOn: []uuid.UUID{e0.UUID},
 	}
@@ -510,21 +511,21 @@ func TestSchedule011(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
-	e3 := Event{
+	e3 := types.Event{
 		Name:  "Test event 3 (TestSchedule011)",
-		State: StateDone,
+		State: types.StateDone,
 		// list of events that must be completed before this event can be processed
 		DependOn:  []uuid.UUID{e1.UUID, e2.UUID},
 		Timestamp: time.Now(),
-		Action: func(e Event) error {
+		Action: func(e types.Event) error {
 			fmt.Println(e.Data.(TestEvent).Message)
-			SetEventState(&e, StateDone)
+			SetEventState(&e, types.StateDone)
 			return nil
 		},
 		Data: TestEvent{
 			Message: testMsg,
 		},
-		Type:        EventTypeCustom,
+		Type:        types.EventTypeCustom,
 		Priority:    1,
 		RepeatEvery: 1,
 		RepeatTimes: 1,
@@ -554,7 +555,7 @@ func TestProcess000(t *testing.T) {
 		t.Errorf(errMsgSchedulerFailedToInit)
 	}
 
-	// ... schedule events ...
+	// ... schedule types.Events ...
 
 	s.Process(config)
 
@@ -572,12 +573,12 @@ func TestProcess001(t *testing.T) {
 		t.Errorf(errMsgSchedulerFailedToInit)
 	}
 
-	// ... schedule events ...
+	// ... schedule types.Events ...
 
-	e := Event{
+	e := types.Event{
 		Name: "Test event (TestProcess001)",
-		Action: func(e Event) error {
-			SetEventState(&e, StateDone)
+		Action: func(e types.Event) error {
+			SetEventState(&e, types.StateDone)
 			return nil
 		},
 	}
@@ -598,11 +599,11 @@ func TestProcess002(t *testing.T) {
 		t.Errorf(errMsgSchedulerFailedToInit)
 	}
 
-	e := Event{
+	e := types.Event{
 		Name: "Test event (TestProcess002)",
-		Action: func(e Event) error {
+		Action: func(e types.Event) error {
 			fmt.Println(e.Data.(TestEvent).Message)
-			SetEventState(&e, StateDone)
+			SetEventState(&e, types.StateDone)
 			return nil
 		},
 		Data: TestEvent{
@@ -627,11 +628,11 @@ func TestProcess003(t *testing.T) {
 		t.Errorf(errMsgSchedulerFailedToInit)
 	}
 
-	e := Event{
+	e := types.Event{
 		Name: "Test event (TestProcess003)",
-		Action: func(e Event) error {
+		Action: func(e types.Event) error {
 			fmt.Println(e.Data.(TestEvent).Message)
-			SetEventState(&e, StateDone)
+			SetEventState(&e, types.StateDone)
 			return nil
 		},
 		Data: TestEvent{
@@ -658,19 +659,19 @@ func TestProcess004(t *testing.T) {
 		t.Errorf(errMsgSchedulerFailedToInit)
 	}
 
-	e0 := Event{
+	e0 := types.Event{
 		Name: "Test event 0 (TestProcess004)",
-		Action: func(e Event) error {
-			SetEventState(&e, StateDone)
+		Action: func(e types.Event) error {
+			SetEventState(&e, types.StateDone)
 			return nil
 		},
 	}
 	_ = s.Schedule(&e0)
-	e1 := Event{
+	e1 := types.Event{
 		Name: "Test event 1 (TestProcess004)",
-		Action: func(e Event) error {
+		Action: func(e types.Event) error {
 			fmt.Println(e.Data.(TestEvent).Message)
-			SetEventState(&e, StateDone)
+			SetEventState(&e, types.StateDone)
 			return nil
 		},
 		Data: TestEvent{
@@ -699,20 +700,20 @@ func TestProcess005(t *testing.T) {
 		t.Errorf(errMsgSchedulerFailedToInit)
 	}
 
-	e0 := Event{
+	e0 := types.Event{
 		Name:  "Test event 0 (TestProcess005)",
-		State: StateDone,
-		Action: func(e Event) error {
-			SetEventState(&e, StateDone)
+		State: types.StateDone,
+		Action: func(e types.Event) error {
+			SetEventState(&e, types.StateDone)
 			return nil
 		},
 	}
 	_ = s.Schedule(&e0)
-	e1 := Event{
+	e1 := types.Event{
 		Name: "Test event 1 (TestProcess005)",
-		Action: func(e Event) error {
+		Action: func(e types.Event) error {
 			fmt.Println(e.Data.(TestEvent).Message)
-			SetEventState(&e, StateDone)
+			SetEventState(&e, types.StateDone)
 			return nil
 		},
 		Data: TestEvent{
@@ -742,19 +743,19 @@ func TestProcess006(t *testing.T) {
 		t.Errorf(errMsgSchedulerFailedToInit)
 	}
 
-	e0 := Event{
+	e0 := types.Event{
 		Name: "Test event 0 (TestProcess006)",
-		Action: func(e Event) error {
-			SetEventState(&e, StateDone)
+		Action: func(e types.Event) error {
+			SetEventState(&e, types.StateDone)
 			return nil
 		},
 	}
 	_ = s.Schedule(&e0)
-	e1 := Event{
+	e1 := types.Event{
 		Name: "Test event 1 (TestProcess006)",
-		Action: func(e Event) error {
+		Action: func(e types.Event) error {
 			fmt.Println(e.Data.(TestEvent).Message)
-			SetEventState(&e, StateDone)
+			SetEventState(&e, types.StateDone)
 			return nil
 		},
 		Data: TestEvent{
@@ -762,8 +763,8 @@ func TestProcess006(t *testing.T) {
 		},
 		Timestamp: time.Now(),
 		DependOn:  []uuid.UUID{e0.UUID},
-		State:     StateDone,
-		Type:      EventTypeCustom,
+		State:     types.StateDone,
+		Type:      types.EventTypeCustom,
 	}
 	_ = s.Schedule(&e1)
 	s.Process(config)
@@ -787,11 +788,11 @@ func TestProcess007(t *testing.T) {
 		t.Errorf(errMsgSchedulerFailedToInit)
 	}
 
-	e := Event{
+	e := types.Event{
 		Name: "Test event (TestProcess007) Random UUID as dependency",
-		Action: func(e Event) error {
+		Action: func(e types.Event) error {
 			fmt.Println(e.Data.(TestEvent).Message)
-			SetEventState(&e, StateDone)
+			SetEventState(&e, types.StateDone)
 			return nil
 		},
 		Data: TestEvent{
@@ -799,8 +800,8 @@ func TestProcess007(t *testing.T) {
 		},
 		Timestamp: time.Now(),
 		DependOn:  []uuid.UUID{uuid.New()},
-		State:     StateDone,
-		Type:      EventTypeCustom,
+		State:     types.StateDone,
+		Type:      types.EventTypeCustom,
 		Priority:  1,
 	}
 	_ = s.Schedule(&e)
@@ -826,19 +827,19 @@ func TestProcess008(t *testing.T) {
 		t.Errorf(errMsgSchedulerFailedToInit)
 	}
 
-	e := Event{
+	e := types.Event{
 		Name: "Test event (TestProcess008) Random UUID as dependency",
-		Action: func(e Event) error {
+		Action: func(e types.Event) error {
 			fmt.Println(e.Data.(TestEvent).Message)
-			SetEventState(&e, StateDone)
+			SetEventState(&e, types.StateDone)
 			return nil
 		},
 		Data: TestEvent{
 			Message: testMsg,
 		},
 		DependOn:    []uuid.UUID{uuid.New()},
-		State:       StateDone,
-		Type:        EventTypeCustom,
+		State:       types.StateDone,
+		Type:        types.EventTypeCustom,
 		Priority:    1,
 		RepeatEvery: 1,
 	}
@@ -866,11 +867,11 @@ func TestProcess009(t *testing.T) {
 		t.Errorf(errMsgSchedulerFailedToInit)
 	}
 
-	e := Event{
+	e := types.Event{
 		Name: "Test event (TestProcess009) Random UUID as dependency",
-		Action: func(e Event) error {
+		Action: func(e types.Event) error {
 			fmt.Println(e.Data.(TestEvent).Message)
-			SetEventState(&e, StateDone)
+			SetEventState(&e, types.StateDone)
 			return nil
 		},
 		Data: TestEvent{
@@ -878,8 +879,8 @@ func TestProcess009(t *testing.T) {
 		},
 		Timestamp:   time.Now(),
 		DependOn:    []uuid.UUID{uuid.New()},
-		State:       StateDone,
-		Type:        EventTypeCustom,
+		State:       types.StateDone,
+		Type:        types.EventTypeCustom,
 		Priority:    1,
 		RepeatEvery: 1,
 		RepeatTimes: 1,
@@ -909,12 +910,12 @@ func TestProcess010(t *testing.T) {
 		t.Errorf(errMsgSchedulerFailedToInit)
 	}
 
-	e := Event{
+	e := types.Event{
 		UUID: uuid.New(),
 		Name: "Test event (TestProcess010) Random UUID as dependency",
-		Action: func(e Event) error {
+		Action: func(e types.Event) error {
 			fmt.Println(e.Data.(TestEvent).Message)
-			SetEventState(&e, StateDone)
+			SetEventState(&e, types.StateDone)
 			return nil
 		},
 		Data: TestEvent{
@@ -922,8 +923,8 @@ func TestProcess010(t *testing.T) {
 		},
 		Timestamp:   time.Now(),
 		DependOn:    []uuid.UUID{uuid.New()},
-		State:       StateDone,
-		Type:        EventTypeCustom,
+		State:       types.StateDone,
+		Type:        types.EventTypeCustom,
 		Priority:    1,
 		RepeatEvery: 1,
 		RepeatTimes: 1,
@@ -954,12 +955,12 @@ func TestProcess011(t *testing.T) {
 		t.Errorf(errMsgSchedulerFailedToInit)
 	}
 
-	e := Event{
+	e := types.Event{
 		UUID: uuid.New(),
 		Name: "Test event (TestProcess011) Random UUID as dependency",
-		Action: func(e Event) error {
+		Action: func(e types.Event) error {
 			fmt.Println(e.Data.(TestEvent).Message)
-			SetEventState(&e, StateDone)
+			SetEventState(&e, types.StateDone)
 			return nil
 		},
 		Data: TestEvent{
@@ -967,8 +968,8 @@ func TestProcess011(t *testing.T) {
 		},
 		Timestamp:   time.Now(),
 		DependOn:    []uuid.UUID{uuid.New()},
-		State:       StateDone,
-		Type:        EventTypeCustom,
+		State:       types.StateDone,
+		Type:        types.EventTypeCustom,
 		Priority:    30,
 		RepeatEvery: 1,
 		RepeatTimes: 1,
@@ -1000,12 +1001,12 @@ func TestProcess012(t *testing.T) {
 		t.Errorf(errMsgSchedulerFailedToInit)
 	}
 
-	e := Event{
+	e := types.Event{
 		UUID: uuid.New(),
 		Name: "Test event (TestProcess012) Random UUID as dependency",
-		Action: func(e Event) error {
+		Action: func(e types.Event) error {
 			fmt.Println(e.Data.(TestEvent).Message)
-			SetEventState(&e, StateDone)
+			SetEventState(&e, types.StateDone)
 			return nil
 		},
 		Data: TestEvent{
@@ -1013,8 +1014,8 @@ func TestProcess012(t *testing.T) {
 		},
 		Timestamp:   time.Now(),
 		DependOn:    []uuid.UUID{uuid.New()},
-		State:       StateDone,
-		Type:        EventTypeCustom,
+		State:       types.StateDone,
+		Type:        types.EventTypeCustom,
 		Priority:    20,
 		RepeatEvery: 1,
 		RepeatTimes: 3,

--- a/registry/datattypes.go
+++ b/registry/datattypes.go
@@ -1,7 +1,7 @@
 package registry
 
 import (
-	"github.com/owasp-amass/engine/events"
+	"github.com/owasp-amass/engine/types"
 )
 
 // plugin interface
@@ -15,9 +15,9 @@ type AmassPlugin interface {
 
 type Handler struct {
 	Name       string
-	EventType  events.EventType
+	EventType  types.EventType
 	Transforms []string
-	Handler    func(*events.Event) error
+	Handler    func(*types.Event) error
 }
 
 type Handlers []Handler

--- a/registry/plugins/plugin_example01/plugin_example.go
+++ b/registry/plugins/plugin_example01/plugin_example.go
@@ -1,18 +1,19 @@
-package plugin_example
+package main
 
 // Amass plugin example
 
 import (
 	"fmt"
+	"time"
 
-	"github.com/owasp-amass/engine/events"
 	"github.com/owasp-amass/engine/registry"
-	// Add OAM dependecy (the Plugin has to deal with the response)
+	"github.com/owasp-amass/engine/types"
+	// Add OAM dependency (the Plugin has to deal with the response)
 )
 
 type PluginOne struct{}
 
-func (p *PluginOne) handleSampleEvent(e *events.Event) error {
+func (p *PluginOne) handleSampleEvent(e *types.Event) error {
 	fmt.Println("PluginOne handling:", e.Data)
 	return nil
 }
@@ -25,7 +26,7 @@ func (p *PluginOne) Start(r *registry.Registry) error {
 		registry.Handler{
 			Name:       "PluginOne-MainHandler",
 			Transforms: []string{"Test-Transform"},
-			EventType:  events.EventTypeLog,
+			EventType:  types.EventTypeLog,
 			Handler:    p.handleSampleEvent,
 		})
 
@@ -33,3 +34,13 @@ func (p *PluginOne) Start(r *registry.Registry) error {
 }
 
 var Plugin PluginOne
+
+// Generic main function
+func main() {
+	fmt.Println("PluginOne main function")
+	// Go to sleep
+	for {
+		// Sleep for 1 second
+		time.Sleep(1 * time.Second)
+	}
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/owasp-amass/engine/events"
+	"github.com/owasp-amass/engine/types"
 )
 
 // Registry storage
@@ -18,14 +18,14 @@ type Registry struct {
 	pluginLock  sync.Mutex
 	plugins     map[string]AmassPlugin
 	handlerLock sync.RWMutex
-	handlers    map[events.EventType]map[string][]Handler
+	handlers    map[types.EventType]map[string][]Handler
 }
 
 // Create a new instance of Registry
 func NewRegistry() *Registry {
 	return &Registry{
 		plugins:  make(map[string]AmassPlugin),
-		handlers: make(map[events.EventType]map[string][]Handler),
+		handlers: make(map[types.EventType]map[string][]Handler),
 	}
 }
 
@@ -81,7 +81,7 @@ func (r *Registry) loadPlugin(path string) (AmassPlugin, error) {
 // Register a Plugin Handler on the registry:
 func (r *Registry) RegisterHandler(h Handler) error {
 	// Check if the event Type is correct
-	if h.EventType < 0 || h.EventType > events.EventType(events.MaxEventTypes) {
+	if h.EventType < 0 || h.EventType > types.EventType(types.MaxEventTypes) {
 		return fmt.Errorf("invalid EventType")
 	}
 
@@ -112,9 +112,9 @@ func (r *Registry) RegisterHandler(h Handler) error {
 }
 
 // Returns a list of handlers for a given event type. Assets can optionally be specified to filter transforms.
-func (r *Registry) GetHandlers(eventType events.EventType, transforms ...string) ([]Handler, error) {
+func (r *Registry) GetHandlers(eventType types.EventType, transforms ...string) ([]Handler, error) {
 	// Check if the event Type is correct
-	if eventType < 0 || eventType > events.EventType(events.MaxEventTypes) {
+	if eventType < 0 || eventType > types.EventType(types.MaxEventTypes) {
 		return nil, fmt.Errorf("invalid EventType")
 	}
 

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -3,7 +3,7 @@ package registry
 import (
 	"testing"
 
-	"github.com/owasp-amass/engine/events"
+	"github.com/owasp-amass/engine/types"
 )
 
 func TestNewRegistry(t *testing.T) {
@@ -13,7 +13,7 @@ func TestNewRegistry(t *testing.T) {
 	}
 }
 
-func FakeHandler(e *events.Event) error {
+func FakeHandler(e *types.Event) error {
 	return nil
 }
 
@@ -25,7 +25,7 @@ func TestRegisterHandler(t *testing.T) {
 		Handler{
 			Name:       "Test-MainHandler",
 			Transforms: []string{"Test-Transform"},
-			EventType:  events.EventTypeLog,
+			EventType:  types.EventTypeLog,
 			Handler:    FakeHandler,
 		})
 

--- a/types/README.md
+++ b/types/README.md
@@ -1,0 +1,13 @@
+# Types package
+
+This package contains the shared types used by the other packages.
+
+## Usage
+
+```go
+import "github.com/your-organization/your-repo/types"
+```
+
+## Index
+
+- [Event](docs/event.md)

--- a/types/docs/event.md
+++ b/types/docs/event.md
@@ -1,0 +1,35 @@
+# Event type
+
+The `Event` type is used to represent an Amass Engine's activity. The following
+example demonstrates how to use the `Event` type:
+
+```go
+package main
+
+import (
+    "fmt"
+
+    "github.com/owasp-amass/amass-engine/types"
+)
+
+type DNSAsset struct {
+    Name    string
+    Domain  string
+    Address string
+}
+
+func main() {
+    event := types.Event{
+        Name:  "My first Event",
+        Type:  types.EventTypeAsset,
+        Data:  DNSAsset{
+            Name:    "example.com",
+            Domain:  "example.com",
+            Address: "",
+        },
+    }
+
+    // ...
+
+}
+```

--- a/types/event.go
+++ b/types/event.go
@@ -1,0 +1,85 @@
+package types
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Event types (are used to query the Registry adn identify the action to be executed)
+type EventType int
+
+const (
+	// SystemType is used to identify system events
+	EventTypeSystem EventType = iota
+	// EventTypeLog is used to log a message to the log file
+	EventTypeLog
+	// EventTypeCustom is used to execute a custom function
+	EventTypeCustom
+	// AssetType is used to identify asset events
+	EventTypeAsset
+	// Add more event types here:
+	// ...
+)
+
+var (
+	// Event types names (used to query the Registry)
+	EventTypeNames = map[EventType]string{
+		EventTypeSystem: "System",
+		EventTypeLog:    "Log",
+		EventTypeCustom: "Custom",
+		EventTypeAsset:  "Asset",
+		// Add more event types here:
+		// ...
+	}
+
+	MaxEventTypes = len(EventTypeNames)
+)
+
+// Event states (are used to control the event flow)
+type EventState int
+
+const (
+	StateDefault EventState = iota // Event is in default state
+	// (normally used when the event is created)
+	StateProcessable // Event is processable (all dependencies are met)
+	StateWaiting     // Event is waiting (some dependencies are not met)
+	StateDone        // Event is done (already processed)
+	StateInProcess   // Event is in process (being processed)
+	StateCancelled   // Event is cancelled (not processed)
+	StateError       // Event is in error (not processed)
+)
+
+// Event is the struct that represents an event
+// This struct it's kind of the "currency of exchange" between the scheduler
+// and the functions that create and process the events
+type Event struct {
+	UUID      uuid.UUID           /* Event UUID */
+	SessionID uuid.UUID           /* Session UUID */
+	Name      string              /* Event name */
+	Timestamp time.Time           /* Event timestamp */
+	Type      EventType           /* Event type */
+	State     EventState          /* Event state (processable, waiting, done, in process) */
+	DependOn  []uuid.UUID         /* Events this event "depends on" */
+	Action    func(e Event) error /* Event handler function (action) (normally populated by querying the
+	-                                Registry)
+	-                              */
+	Priority    int /* Event priority (normally populated by querying the Registry) */
+	RepeatEvery int /* Event repeat every X milliseconds
+	-                  0 means repeat immediately
+	-                  n means repeat after n milliseconds (n > 0)
+	-                  Event won't be repeated if RepeatTimes is 0
+	-                */
+	RepeatTimes int /* Event repeat times (normally populated by querying the Registry)
+	-                  -1 means repeat forever
+	-                   0 means don't repeat
+	-                   n means repeat n times
+	-                 */
+	Data interface{} /* This field can hold any data type (normally populated by the function
+	-                   that creates the event, and used by the function that processes the
+	-                   event)
+	-                 */
+	Timeout time.Time   /* Timeout timer (used to cancel the event if it's not processed in time) */
+	Sched   interface{} /* Pointer to the scheduler that created the event */
+	Session interface{} /* Pointer to the session that created the event */
+}


### PR DESCRIPTION
This PR introduces a new "types" package which is meant to contain all the shared types across Amass Engine.

At the moment it contains only event.go that describes the event type.

This PR also has refactoring for registry and events (the scheduler now) to use types and has a fully completed plugin example that builds correctly.