### PR TITLE
Added backend Session and Global Scheduler Status 

### DIFF
--- a/cmd/amass_engine/main.go
+++ b/cmd/amass_engine/main.go
@@ -43,8 +43,8 @@ func main() {
 		CheckEvent:           false,
 		ExecuteAction:        true,
 		ReturnIfFound:        false,
-		DebugLevel:           3,
-		ActionTimeout:        6000,
+		DebugLevel:           0,
+		ActionTimeout:        0,
 		MaxConcurrentActions: 8,
 	}
 

--- a/scheduler/types.go
+++ b/scheduler/types.go
@@ -19,6 +19,20 @@ var (
 	zeroUUID = uuid.UUID{}
 )
 
+type schedulerStats struct {
+	TotalEventsReceived      int
+	TotalEventsDone          int
+	TotalEventsCancelled     int
+	TotalEventsInProcess     int
+	TotalEventsError         int
+	TotalEventsWaiting       int
+	TotalEventsProcessable   int
+	TotalEventsSystem        int
+	SessionEventsInProcess   int
+	SessionEventsWaiting     int
+	SessionEventsProcessable int
+}
+
 type SchedulerState int
 
 const (
@@ -43,6 +57,7 @@ type Scheduler struct {
 	logger                *log.Logger                // Logger
 	r                     *registry.Registry         // Plugins registry
 	s                     *sessions.Manager
+	stats                 schedulerStats
 }
 
 // ProcessConfig is the struct that represents the configuration used to process the events

--- a/types/event.go
+++ b/types/event.go
@@ -83,3 +83,18 @@ type Event struct {
 	Sched   interface{} /* Pointer to the scheduler that created the event */
 	Session interface{} /* Pointer to the session that created the event */
 }
+
+// StatsResponse is the struct that represents the response to the Stats request
+type StatsResponse struct {
+	TotalEvents            int
+	TotalEventsDone        int
+	TotalEventsCancelled   int
+	TotalEventsInProcess   int
+	TotalEventsError       int
+	TotalEventsWaiting     int
+	TotalEventsProcessable int
+	TotalEventsSystem      int
+	SessionEvents          int
+	SessionEventsInProcess int
+	SessionEventsWaiting   int
+}


### PR DESCRIPTION
This PR contains:

- Added scheduler statistics (backend function)
- Session statistics (backend function)
- Changed the default scheduler config to avoid having too many messages being logged in the file log

This PR is required to complete SessionStatus and GlobalStatus GraphQL queries
