### PR TITLE
Updated engine stats to support both system wide stats and session only stats

### DIFF
--- a/scheduler/types.go
+++ b/scheduler/types.go
@@ -20,18 +20,17 @@ var (
 )
 
 type schedulerStats struct {
-	TotalEventsReceived      int
-	TotalEventsDone          int
-	TotalEventsCancelled     int
-	TotalEventsInProcess     int
-	TotalEventsError         int
-	TotalEventsWaiting       int
-	TotalEventsProcessable   int
-	TotalEventsSystem        int
-	SessionEventsInProcess   int
-	SessionEventsWaiting     int
-	SessionEventsProcessable int
+	TotalEventsReceived    int
+	TotalEventsDone        int
+	TotalEventsCancelled   int
+	TotalEventsInProcess   int
+	TotalEventsError       int
+	TotalEventsWaiting     int
+	TotalEventsProcessable int
+	TotalEventsSystem      int
 }
+
+// SchedulerState is the struct that represents the scheduler state
 
 type SchedulerState int
 

--- a/types/event.go
+++ b/types/event.go
@@ -18,6 +18,8 @@ const (
 	EventTypeCustom
 	// AssetType is used to identify asset events
 	EventTypeAsset
+	// UnknownType is used to identify unknown events (or all events)
+	EventTypeUnknown
 	// Add more event types here:
 	// ...
 )
@@ -25,10 +27,11 @@ const (
 var (
 	// Event types names (used to query the Registry)
 	EventTypeNames = map[EventType]string{
-		EventTypeSystem: "System",
-		EventTypeLog:    "Log",
-		EventTypeCustom: "Custom",
-		EventTypeAsset:  "Asset",
+		EventTypeSystem:  "System",
+		EventTypeLog:     "Log",
+		EventTypeCustom:  "Custom",
+		EventTypeAsset:   "Asset",
+		EventTypeUnknown: "Unknown",
 		// Add more event types here:
 		// ...
 	}
@@ -85,16 +88,19 @@ type Event struct {
 }
 
 // StatsResponse is the struct that represents the response to the Stats request
-type StatsResponse struct {
-	TotalEvents            int
-	TotalEventsDone        int
-	TotalEventsCancelled   int
-	TotalEventsInProcess   int
-	TotalEventsError       int
-	TotalEventsWaiting     int
-	TotalEventsProcessable int
-	TotalEventsSystem      int
-	SessionEvents          int
-	SessionEventsInProcess int
-	SessionEventsWaiting   int
+type SystemStatsResponse struct {
+	TotalWorkItemsReceived    int
+	TotalWorkItemsDone        int
+	TotalWorkItemsCancelled   int
+	TotalWorkItemsProcess     int
+	TotalWorkItemsError       int
+	TotalWorkItemsWaiting     int
+	TotalWorkItemsProcessable int
+	TotalWorkItemsSystem      int
+}
+
+type SessionStatsResponse struct {
+	SessionWorkItemsInProcess   int
+	SessionWorkItemsWaiting     int
+	SessionWorkItemsProcessable int
 }


### PR DESCRIPTION
This PR contains:

- Two separate function to query for statistics, GetSystemStats and GetSessionStats
- GetSessionStats require a session Id and an event type
- GetSysstemStats has no parameters
- They both return stats defined in types <---- so no event terminology is used

